### PR TITLE
Updated the example to use PHP OpenStack 3.0.5

### DIFF
--- a/php-opencloud-example/README.md
+++ b/php-opencloud-example/README.md
@@ -1,7 +1,7 @@
 This is an example on how to connect to Memstore using php-opencloud.
 
-Tested with php-opencloud 1.9.2.
- 
+Tested with php-opencloud 3.0.5.
+
 The auth service description is at:
 
  https://auth.storage.memset.com/v2.0

--- a/php-opencloud-example/example.php
+++ b/php-opencloud-example/example.php
@@ -1,23 +1,38 @@
 <?php
-// This is example.php
 
-require 'vendor/autoload.php';
+require __DIR__ . '/vendor/autoload.php';
 
-use OpenCloud\OpenStack;
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use OpenStack\Common\Transport\Utils as TransportUtils;
+use OpenStack\Identity\v2\Service;
+use OpenStack\OpenStack;
+
+$authUrl = 'https://auth-host.local/v2.0';
+
+$httpClient = new Client([
+    'base_uri' => TransportUtils::normalizeUrl($authUrl),
+    'handler'  => HandlerStack::create(),
+]);
 
 $client = new OpenStack(
-    'https://auth-host.local/v2.0',
-    array(
+    [
+        'authUrl' => $authUrl,
+        'region' => 'reading',
         'username' => 'admin',
-		'password' => 'YOUR-PASSWORD',
-        'tenantName' => 'YOUR-MEMSTORE' // ie. mstestaa1
-    ));
+        'password' => 'YOUR-PASSWORD',
+        'tenantName' => 'YOUR-MEMSTORE', // e.g. mstestaa1
+        'identityService' => Service::factory($httpClient),
+    ]
+);
 
-$service = $client->objectStoreService("memstore", "reading");
+$service = $client->objectStoreV1(
+    [
+        'catalogName' => 'memstore',
+    ]
+);
 
 $containers = $service->listContainers();
 foreach ($containers as $container) {
-    printf("Container name: %s\n", $container->getName());
+    printf("Container name: %s\n", $container->getObject()->containerName);
 }
-
-?>


### PR DESCRIPTION
After a lot of digging around in the OpenStack SDK I found the method to connect to MemStore containers. As the v1.* versions of the SDK use the deprecated v3.* of Guzzle, it makes sense to upgrade. I'm sharing this here as it might help others who are looking to integrate.